### PR TITLE
Human argument order in decorator

### DIFF
--- a/subcmd/decorators.py
+++ b/subcmd/decorators.py
@@ -56,7 +56,7 @@ def option(*args, **kwds):
     def _decorator(func):
         _option = (args, kwds)
         if hasattr(func, 'options'):
-            func.options.append(_option)
+            func.options.insert(0, _option)
         else:
             func.options = [_option]
         return func


### PR DESCRIPTION
When you decorate a function with multiple `@arg` or `@option` like

``` python
@arg('foo', help='Foo')
@arg('bar', help='Bar')
def do_some(options):
  print "The function!"
```

Then the order for the command is:

``` bash
$ cmd bar foo
```

This is because decorators are processed from in to out.
http://docs.python.org/reference/compound_stmts.html#function
This change could be harmful, because may break prior versions
which use positional arguments.
